### PR TITLE
Fix Location of Golden State Warriors

### DIFF
--- a/basketball/nba-team.json
+++ b/basketball/nba-team.json
@@ -270,12 +270,6 @@
     "logoUrl": "cxe7hh6lwjtpdhcoyiuc064sp.gif"
   },
   {
-    "name": "Warriors",
-    "location": "San Francisco",
-    "score": 446.1,
-    "logoUrl": "5972.gif"
-  },
-  {
     "name": "Bombers",
     "location": "St. Louis",
     "score": 0,

--- a/basketball/nba-team.json
+++ b/basketball/nba-team.json
@@ -90,8 +90,8 @@
     "score": 0
   },
   {
-    "name": "Warriors",
-    "location": "Golden State",
+    "name": "Golden State Warriors",
+    "location": "San Francisco",
     "logoUrl": "Warriors_Golden_State.gif",
     "score": 446.1
   },


### PR DESCRIPTION
The location returned `Golden State` and the team name returned `Warriors`. Updated it to return `San Francisco` for location and `Golden State Warriors` for the team name.

![image](https://user-images.githubusercontent.com/7775978/77020399-dd4f3300-6940-11ea-9bec-75bc75c037a2.png)
